### PR TITLE
Add an errorCount parameter to `testGenerator` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ When you override `logError()` this plugin won't log any warnings or errors.
 
 ### testGenerator()
 
-| Type       | Function                        |
-|------------|---------------------------------|
-| function   | fileLint (relativePath, errors) |
+| Type       | Function                                    |
+|------------|---------------------------------------------|
+| function   | fileLint (relativePath, errors, errorCount) |
 
 The function used to generate test modules. You can provide a custom function for your client side testing framework of choice.
 
@@ -105,6 +105,7 @@ The function receives the following arguments:
 
 * `relativePath` - The relative path to the file being tested.
 * `errors` - A generated string of errors found.
+* `errorCount` - An integer of the number of errors found per file.
 
 Default generates QUnit style tests:
 
@@ -122,6 +123,17 @@ function(relativePath, errors) {
          "});\n";
 };
 ```
+
+Example of using errorCount with mocha and chai with `errorCount`:
+
+```javascript
+"describe('Sass Lint - " + path.dirname(relativePath) + "', function() { \n" +
+" it('" + relativePath + " should pass sass-lint', function() {\n" +
+"   expect(" + errorCount + ").to.eq(0);\n" +
+" });\n" +
+"});\n";
+```
+
 ---
 
 ## Development

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ SassLinter.prototype.processString = function(content, relativePath) {
 
   if (!this.disableTestGenerator) {
     // Return generated test
-    return this.testGenerator(relativePath, this.formatErrors([lint]));
+    return this.testGenerator(relativePath, this.formatErrors([lint]), linter.errorCount);
   }
 
   return content; // Return unmodified string
@@ -231,7 +231,7 @@ be included and run by PhantomJS. If there are any errors, the test will fail
 and print the reasons for failing. If there are no errors, the test will pass.
 */
 
-SassLinter.prototype.testGenerator = function(relativePath, errors) {
+SassLinter.prototype.testGenerator = function(relativePath, errors, errorCount) {
   if (errors) {
     errors = this.escapeErrorString('\n' + errors);
   }


### PR DESCRIPTION
This lets implementing applications write tests for the `testGenerator` based directly on the count of errors, as opposed to parsing the string. For example,

```
"describe('Sass Lint - " + path.dirname(relativePath) + "', function() { \n" +
"  it('" + relativePath + " should pass sass-lint', function() {\n" +
"    expect(" + (errors.search(/problem(s)? \([1-9][0-9]* error/i) > 0) + ").to.be.false;\n" +
"  });\n" +
"});\n";
```

can become:

```
"describe('Sass Lint - " + path.dirname(relativePath) + "', function() { \n" +
" it('" + relativePath + " should pass sass-lint', function() {\n" +
"   expect(" + errorCount + ").to.eq(0);\n" +
" });\n" +
"});\n";
```

@sir-dunxalot I didn't update the tests to include this new variable, wanted to get some feedback to see if this makes sense. What do you think?